### PR TITLE
support adding listener to multiple events

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,31 @@
 'use strict';
 
 function listen(target, eventType, callback) {
+  if (typeof eventType != 'string') {
+    throw new TypeError('eventType must be a string')
+  }
+  var eventTypes = eventType.split(' ').filter(Boolean)
   if (target.addEventListener) {
-    target.addEventListener(eventType, callback, false)
+    eventTypes.forEach(function (eventType) {
+      target.addEventListener(eventType, callback, false)
+    })
     return {
       remove: function() {
-        target.removeEventListener(eventType, callback, false)
+        eventTypes.forEach(function (eventType) {
+          target.removeEventListener(eventType, callback, false)
+        })
       }
     }
   }
   else if (target.attachEvent) {
-    target.attachEvent('on' + eventType, callback)
+    eventTypes.forEach(function (eventType) {
+      target.attachEvent('on' + eventType, callback)
+    })
     return {
       remove: function() {
-        target.detachEvent('on' + eventType, callback)
+        eventTypes.forEach(function (eventType) {
+          target.detachEvent('on' + eventType, callback)
+        })
       }
     }
   }


### PR DESCRIPTION
It would result better code in case when you want to attach the same function to different events:

``` js
var listener = addEventListener(window, 'resize orientationchange', fn);

// ...

listener.remove();
```

instead of:

``` js
var listener1 = addEventListener(window, 'resize', fn);
var listener2 = addEventListener(window, 'orientationchange', fn);

// ...

listener1.remove();
listener2.remove();
```
